### PR TITLE
Add initial marketplace scaffolding

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "modernize-plugins",
+  "metadata": {
+    "description": "Code modernization plugins for GitHub Copilot",
+    "version": "1.0.0-preview"
+  },
+  "owner": {
+    "name": "Microsoft"
+  },
+  "plugins": [
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*~
+
+# Node (in case plugins ship JS tooling)
+node_modules/
+npm-debug.log*
+yarn-error.log*
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# .NET
+bin/
+obj/
+
+# Local environment
+.env
+.env.local

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,274 @@
+**MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS**
+
+**MICROSOFT GITHUB COPILOT MODERNIZATION -- PREVIEW**
+
+These license terms are an agreement between you and Microsoft
+Corporation (or one of its affiliates). They apply to the pre-release
+software named above and any Microsoft services or software updates
+(except to the extent such services or updates are accompanied by new or
+additional terms, in which case those different terms apply
+prospectively and do not alter your or Microsoft's rights relating to
+pre-updated software or services). IF YOU COMPLY WITH THESE LICENSE
+TERMS, YOU HAVE THE RIGHTS BELOW. BY USING THE SOFTWARE, YOU ACCEPT
+THESE TERMS.
+
+1.  **INSTALLATION AND USE RIGHTS.**
+
+    -   a\) General. You may install and use any number of copies of the
+        software only with Microsoft Visual Studio and successor
+        Microsoft products and services to develop and test your
+        applications.
+
+    -   b\) GitHub Copilot and Other Third-Party Components. The
+        software contains libraries that enable you to interact with the
+        GitHub Copilot service ("Copilot") offered by GitHub, Inc.
+        ("GitHub"). You must separately obtain access to Copilot to use
+        this functionality, and your use of Copilot is pursuant to the
+        separate agreement(s) between you and GitHub, including any data
+        collection provisions. The software may also include third-party
+        components with separate legal notices or governed by other
+        agreements, as may be described in the notices file(s)
+        accompanying the software.
+
+2.  **PRE-RELEASE SOFTWARE.** This software is a pre-release version. It
+    may not operate correctly or work the way a final version will.
+    Microsoft may change it for the final, commercial version. Microsoft
+    is not obligated to provide maintenance, technical support or
+    updates to you for the software.
+
+3.  **CONFIDENTIAL INFORMATION. **The software, including its user
+    interface, features and documentation, is confidential and
+    proprietary to Microsoft and its suppliers. 
+
+    -   a\) Use. For two years after installation of the software or its
+        commercial release, whichever is first, you may not disclose
+        confidential information to third parties. You may disclose
+        confidential information only to your employees and consultants
+        who need to know the information. You must have written
+        agreements with them that protect the confidential information
+        at least as much as this agreement. 
+
+    -   b\) Survival. Your duty to protect confidential information
+        survives this agreement. 
+
+    -   c\) Exclusions. You may disclose confidential information in
+        response to a judicial or governmental order. You must first
+        give written notice to Microsoft to allow it to seek a
+        protective order or otherwise protect the information.
+        Confidential information does not include information that: 
+
+        -   becomes publicly known through no wrongful act; 
+
+        -   you received from a third party who did not breach
+            confidentiality obligations to Microsoft or its suppliers;
+            or 
+
+        -   you developed independently.
+
+4.  **FEEDBACK. **If you give feedback about the software to Microsoft,
+    you give to Microsoft, without charge, the right to use, share and
+    commercialize your feedback in any way and for any purpose. You will
+    not give feedback that is subject to a license that requires
+    Microsoft to license its software or documentation to third parties
+    because we include your feedback in them. These rights survive this
+    agreement.
+
+5.  **TIME-SENSITIVE SOFTWARE.**
+
+    -   • Period. This agreement is effective on your acceptance and
+        terminates on the earlier of (i) 30 days following first
+        availability of a commercial release of the software or (ii)
+        upon termination by Microsoft. Microsoft may extend this
+        agreement in its discretion.
+
+    -   • Notice. You may receive periodic reminder notices of this date
+        through the software.
+
+    -   • Access to data. You may not be able to access data used in the
+        software when it stops running.
+
+6.  **SCOPE OF LICENSE. **The software is licensed, not sold. This
+    agreement only gives you some rights to use the software. Microsoft
+    reserves all other rights. For clarification Microsoft, or its
+    licensors, retains ownership of all aspects of the software. Unless
+    applicable law gives you more rights despite this limitation, you
+    may use the software only as expressly permitted in this agreement.
+    In doing so, you must comply with any technical limitations in the
+    software that only allow you to use it in certain ways. For example,
+    if Microsoft technically limits or disables extensibility for the
+    software, you may not extend the software by, among other things,
+    loading or injecting into the software any non-Microsoft add-ins,
+    macros, or packages; modifying the software registry settings; or
+    adding features or functionality equivalent to that found in
+    Microsoft products and services. You may not: a) work around any
+    technical limitations in the software that only allow you to use it
+    in certain ways; b) reverse engineer, decompile or disassemble the
+    software, or otherwise attempt to derive the source code for the
+    software, except and to the extent required by third party licensing
+    terms governing use of certain open source components that may be
+    included in the software; c) remove, minimize, block, or modify any
+    notices of Microsoft or its suppliers in the software; d) use the
+    software in any way that is against the law or to create or
+    propagate malware; e) share, publish, distribute, or lease the
+    software; or f) provide the software as a stand-alone offering or
+    combine it with any of your applications for others to use, or
+    transfer the software or this agreement to any third party.
+
+7.  **DATA.**
+
+    -   a\) Data Collection. The software may collect information about
+        you and your use of the software, and send that to Microsoft.
+        Microsoft may use this information to provide services and
+        improve our products and services. You may opt-out of many of
+        these scenarios, but not all, as described in the software
+        documentation located at
+        https://code.visualstudio.com/docs/supporting/faq#\_how-to-disable-telemetry-reporting.
+        There are also some features in the software that may enable you
+        and Microsoft to collect data from users of your applications.
+        If you use these features, you must comply with applicable law,
+        including providing appropriate notices to users of your
+        applications together with a copy of Microsoft's privacy
+        statement. Our privacy statement is located at
+        https://aka.ms/privacy. You can learn more about data collection
+        and its use from the software documentation and our privacy
+        statement. Your use of the software operates as your consent to
+        these practices.
+
+    -   b\) Data sharing with GitHub, Inc. Microsoft may share the data
+        identified in subsection (a) with GitHub for the purpose of
+        improving Copilot and the software.
+
+8.  **EXPORT RESTRICTIONS. **You must comply with all domestic and
+    international export laws and regulations that apply to the
+    software, which include restrictions on destinations, end users, and
+    end use. For further information on export restrictions, visit
+    https://aka.ms/exporting.
+
+9.  **SUPPORT SERVICES. **Microsoft is not obligated under this
+    agreement to provide any support services for the software. Any
+    support provided is "as is", "with all faults", and without warranty
+    of any kind. 
+
+10. **ENTIRE AGREEMENT. **Without limiting Section 1(b), this agreement,
+    and any other terms Microsoft may provide for supplements, updates,
+    or third-party applications, is the entire agreement for the
+    software.
+
+11. **APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES.** If you acquired
+    the software in the United States or Canada, the laws of the state
+    or province where you live (or, if a business, where your principal
+    place of business is located) govern the interpretation of this
+    agreement, claims for its breach, and all other claims (including
+    consumer protection, unfair competition, and tort claims),
+    regardless of conflict of laws principles. If you acquired the
+    software in any other country, its laws apply. If U.S. federal
+    jurisdiction exists, you and Microsoft consent to exclusive
+    jurisdiction and venue in the federal court in King County,
+    Washington for all disputes heard in court. If not, you and
+    Microsoft consent to exclusive jurisdiction and venue in the
+    Superior Court of King County, Washington for all disputes heard in
+    court.
+
+12. **CONSUMER RIGHTS; REGIONAL VARIATIONS. **This agreement describes
+    certain legal rights. You may have other rights, including consumer
+    rights, under the laws of your state or country. Separate and apart
+    from your relationship with Microsoft, you may also have rights with
+    respect to the party from which you acquired the software. This
+    agreement does not change those other rights if the laws of your
+    state or country do not permit it to do so. For example, if you
+    acquired the software in one of the below regions, or mandatory
+    country law applies, then the following provisions apply to you:
+
+    -   a\) Australia. You have statutory guarantees under the
+        Australian Consumer Law and nothing in this agreement is
+        intended to affect those rights.
+
+    -   b\) Canada. If you acquired this software in Canada, you may
+        stop receiving updates by turning off the automatic update
+        feature, disconnecting your device from the Internet (if and
+        when you re-connect to the Internet, however, the software will
+        resume checking for and installing updates), or uninstalling the
+        software. The product documentation, if any, may also specify
+        how to turn off updates for your specific device or software.
+
+    -   c\) Germany and Austria. i. Warranty. The properly licensed
+        software will perform substantially as described in any
+        Microsoft materials that accompany the software. However,
+        Microsoft gives no contractual guarantee in relation to the
+        licensed software. ii. Limitation of Liability. In case of
+        intentional conduct, gross negligence, claims based on the
+        Product Liability Act, as well as, in case of death or personal
+        or physical injury, Microsoft is liable according to the
+        statutory law. Subject to the foregoing clause ii., Microsoft
+        will only be liable for slight negligence if Microsoft is in
+        breach of such material contractual obligations, the fulfillment
+        of which facilitate the due performance of this agreement, the
+        breach of which would endanger the purpose of this agreement and
+        the compliance with which a party may constantly trust in
+        (so-called \"cardinal obligations\"). In other cases of slight
+        negligence, Microsoft will not be liable for slight negligence. 
+
+13. **DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED "AS IS." YOU BEAR
+    THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES,
+    GUARANTEES, OR CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE
+    LAWS, MICROSOFT EXCLUDES ALL IMPLIED WARRANTIES, INCLUDING
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+    NON-INFRINGEMENT. **
+
+14. **LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR
+    RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU
+    CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP
+    TO U.S. \$5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING
+    CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT, OR INCIDENTAL
+    DAMAGES.** \*\*This limitation applies to (a) anything related to
+    the software, services, content (including code) on third party
+    Internet sites, or third party applications; and (b) claims for
+    breach of contract, warranty, guarantee, or condition; strict
+    liability, negligence, or other tort; or any other claim; in each
+    case to the extent permitted by applicable law. It also applies even
+    if Microsoft knew or should have known about the possibility of the
+    damages. The above limitation or exclusion may not apply to you
+    because your state, province, or country may not allow the exclusion
+    or limitation of incidental, consequential, or other damages.\*\*
+
+Please note: As this software is distributed in Canada, some of the
+clauses in this agreement are provided below in French.\
+\
+Remarque: Ce logiciel étant distribué au Canada, certaines des clauses
+dans ce contrat sont fournies ci-dessous en français.\
+\
+**EXONÉRATION DE GARANTIE.** Le logiciel visé par une licence est offert
+« tel quel ». Toute utilisation de ce logiciel est à votre seule risque
+et péril. Microsoft n'accorde aucune autre garantie expresse. Vous
+pouvez bénéficier de droits additionnels en vertu du droit local sur la
+protection des consommateurs, que ce contrat ne peut modifier. La ou
+elles sont permises par le droit locale, les garanties implicites de
+qualité marchande, d'adéquation à un usage particulier et d'absence de
+contrefaçon sont exclues.\
+\
+**LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR
+LES DOMMAGES.** Vous pouvez obtenir de Microsoft et de ses fournisseurs
+une indemnisation en cas de dommages directs uniquement à hauteur de
+5,00 \$ US. Vous ne pouvez prétendre à aucune indemnisation pour les
+autres dommages, y compris les dommages spéciaux, indirects ou
+accessoires et pertes de bénéfices. Cette limitation concerne:
+
+-   tout ce qui est relié au logiciel, aux services ou au contenu (y
+    compris le code) figurant sur des sites Internet tiers ou dans des
+    programmes tiers; et
+
+-   les réclamations au titre de violation de contrat ou de garantie, ou
+    au titre de responsabilité stricte, de négligence ou d'une autre
+    faute dans la limite autorisée par la loi en vigueur.
+
+Elle s'applique également, même si Microsoft connaissait ou devrait
+connaître l'éventualité d'un tel dommage. Si votre pays n'autorise pas
+l'exclusion ou la limitation de responsabilité pour les dommages
+indirects, accessoires ou de quelque nature que ce soit, il se peut que
+la limitation ou l'exclusion ci-dessus ne s'appliquera pas à votre
+égard.\
+\
+**EFFET JURIDIQUE.** Le présent contrat décrit certains droits
+juridiques. Vous pourriez avoir d'autres droits prévus par les lois de
+votre pays. Le présent contrat ne modifie pas les droits que vous
+confèrent les lois de votre pays si celles-ci ne le permettent pas.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Modernize
+
+A GitHub Copilot CLI plugin marketplace for AI-assisted application modernization.
+
+This repository will host plugins that help you upgrade, migrate, and modernize applications across languages, frameworks, and platforms. It is published as a [Copilot CLI plugin marketplace](https://docs.github.com/en/copilot/github-copilot-cli) — once plugins are added here, you can install them into your Copilot CLI with a single command.
+
+> [!NOTE]
+> No plugins are published yet. Track progress in [Issues](https://github.com/microsoft/modernize/issues).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com). If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,11 @@
+# Support
+
+## How to file issues and get help
+
+This project uses [GitHub Issues](https://github.com/microsoft/modernize/issues) to track bugs and feature requests. Please search the existing issues before filing new ones to avoid duplicates. For new issues, file your bug or feature request as a new issue.
+
+For help and questions about using this project, please open a [discussion](https://github.com/microsoft/modernize/discussions) or file an issue using the question template.
+
+## Microsoft Support Policy
+
+Support for this project is limited to the resources listed above.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,52 @@
+# Plugins
+
+Each subdirectory of `plugins/` is a single Copilot CLI plugin published by this marketplace. There are no plugins here yet — this document describes the expected layout so contributors can add one.
+
+## Expected layout
+
+```
+plugins/<plugin-name>/
+├── .github/
+│   └── plugin/
+│       └── plugin.json         # Plugin manifest (required)
+├── agents/
+│   └── <plugin-name>.agent.md  # Agent definition(s) the plugin contributes
+├── hooks/                      # Optional: lifecycle hook scripts
+│   └── scripts/
+├── hooks.json                  # Optional: hook registrations
+└── README.md                   # Plugin-specific overview and usage
+```
+
+## `plugin.json`
+
+Minimum fields:
+
+```json
+{
+  "name": "<plugin-name>",
+  "version": "0.1.0",
+  "description": "Short, user-facing description of what the plugin does.",
+  "author": { "name": "Microsoft" },
+  "keywords": ["modernization"],
+  "repository": "https://github.com/microsoft/modernize",
+  "license": "MIT"
+}
+```
+
+Add `"hooks": "hooks.json"` only if the plugin ships hook scripts.
+
+## Installation (from this marketplace)
+
+```
+/plugin marketplace add microsoft/modernize
+/plugin install <plugin-name>@modernize
+```
+
+## Naming
+
+- Use lowercase, hyphen-separated names that match the folder name.
+- Names must be unique within this marketplace.
+
+## Proposing a new plugin
+
+See [`../CONTRIBUTING.md`](../CONTRIBUTING.md). Open a **Plugin proposal** issue before sending a PR.


### PR DESCRIPTION
Sets up the repo as a Copilot CLI plugin marketplace with no plugins yet:
- .github/plugin/marketplace.json with an empty plugins array
- README explaining the marketplace
- plugins/ directory with a README documenting the expected plugin layout
- Microsoft OSS files: LICENSE.md, CODE_OF_CONDUCT.md, SECURITY.md, SUPPORT.md
- .gitignore