### PR TITLE
Update upgrade-agent plugin to 1.1.247

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "upgrade-agent-plugins",
   "metadata": {
     "description": "GitHub Copilot upgrade plugins",
-    "version": "1.1.222"
+    "version": "1.1.247"
   },
   "owner": {
     "name": "Microsoft"
@@ -12,7 +12,7 @@
       "name": "upgrade-agent",
       "source": "./plugins/upgrade-agent",
       "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-      "version": "1.1.222"
+      "version": "1.1.247"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Added a connect timeout to the Upgrade MCP server configuration to prevent indefinite startup hangs.
+- Increased the Upgrade MCP server startup timeout so its tools load reliably when the server is slow to start.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the upgrade-agent plugin are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.247] - 2026-07-22
+
+### Changed
+
+- Added a connect timeout to the Upgrade MCP server configuration to prevent indefinite startup hangs.
+
+### Fixed
+
+- Fixed an inverted SDK-style project guard that caused the Azure Functions upgrade analysis rule (`AzureFunctionsUpgrade.0001`) to be skipped.
+- Fixed invalid JSON in the YARP scaffold `launchSettings.json` templates.
+
 ## [1.1.222] - 2026-07-16
 
 ### Changed

--- a/plugins/upgrade-agent/agents/upgrade.agent.md
+++ b/plugins/upgrade-agent/agents/upgrade.agent.md
@@ -7,13 +7,20 @@ mcp-servers:
     command: 'dnx'
     args: [
       'Microsoft.GitHubCopilot.Upgrade.Mcp',
-      '--prerelease',
       '--yes',
       '--ignore-failed-sources'
     ]
     cwd: '~'
     tools: ['*']
     deferTools: 'never'
+    # On a cold NuGet cache, `dnx` has to hit the feed, download,
+    # and extract the package before it can answer the MCP `initialize`
+    # handshake. The host's connect timeout floor is max(timeout, 60000)ms
+    # (capped at 600000ms) - the 60s default is often not enough, which
+    # silently drops the Upgrade tools for the first turn (they show up once
+    # the package is cached). 300000 (5 min) gives the cold start headroom
+    # while staying well under the 10-minute cap.
+    timeout: 300000
     env:
       # NOTE: the local inner-loop installer (tools/install-local.ps1) builds
       # its own env block by hand and does NOT read this file. If you add,

--- a/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade-extension.json
+++ b/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade-extension.json
@@ -6,7 +6,6 @@
     "command": "dnx",
     "args": [
       "Microsoft.GitHubCopilot.Upgrade.DotNet.Mcp",
-      "--prerelease",
       "--yes",
       "--ignore-failed-sources"
     ]

--- a/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/SKILL.md
+++ b/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/SKILL.md
@@ -125,7 +125,7 @@ the `$placeholder$` variables:
 | `$HttpsPort$` | HTTPS port (pick 7100-7999, avoid old project's ports) |
 | `$HttpPort$` | HTTP port (pick 5100-5999, avoid old project's ports) |
 | `$NewPort$` | IIS Express HTTP port (pick 60000-65000) |
-| `$NewSslPort$` | IIS Express SSL port (pick 44300-44399) |
+| `$NewSslPort$` | IIS Express SSL port (pick 44300-44399) — in `launchSettings.json` this placeholder is quoted (`"sslPort": "$NewSslPort$"`) so the template stays valid JSON; after substituting, remove the surrounding quotes so `sslPort` stays a JSON number, e.g. `"sslPort": 44355` |
 | `$OldAppUrl$` | Old app's URL (e.g., `https://localhost:44319`) |
 
 Then manually:

--- a/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/scaffold-project.ps1
+++ b/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/scaffold-project.ps1
@@ -129,6 +129,13 @@ function Copy-TemplateWithSubstitutions {
         foreach ($key in $Vars.Keys) {
             $content = $content.Replace($key, $Vars[$key])
         }
+
+        # launchSettings.json templates author "sslPort" as a quoted placeholder
+        # (e.g. "sslPort": "$NewSslPort$") so the template itself is valid JSON;
+        # unquote the substituted value here since IIS Express expects sslPort
+        # as a JSON number, not a string.
+        $content = $content -replace '("sslPort":\s*)"(\d+)"', '$1$2'
+
         [System.IO.File]::WriteAllText($destFile, $content, [System.Text.UTF8Encoding]::new($false))
         Write-Host "    -> $relativePath"
     }

--- a/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/tmpl/mvc/Properties/launchSettings.json
+++ b/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/tmpl/mvc/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:$NewPort$",
-      "sslPort": $NewSslPort$
+      "sslPort": "$NewSslPort$"
     }
   },
   "profiles": {

--- a/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/tmpl/webapi/Properties/launchSettings.json
+++ b/plugins/upgrade-agent/extenders/upgrade-dotnet/upgrade/skills/lazy/web/mvc/scaffolding-yarp-proxy-project/tmpl/webapi/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:$NewPort$",
-      "sslPort": $NewSslPort$
+      "sslPort": "$NewSslPort$"
     }
   },
   "profiles": {

--- a/plugins/upgrade-agent/plugin.json
+++ b/plugins/upgrade-agent/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade-agent",
-  "version": "1.1.222",
+  "version": "1.1.247",
   "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
   "author": {
     "name": "Microsoft"


### PR DESCRIPTION
Automated update of upgrade-agent plugin from UpgradeAssistant build 2026-07-22-20260722.2 (version 1.1.247).