### PR TITLE
Update CCA setup to use upgrade-agent-actions

### DIFF
--- a/cloud-agent/linux/copilot-setup-steps.yml
+++ b/cloud-agent/linux/copilot-setup-steps.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: dotnet/modernize-dotnet-actions@upgrade-agent-actions
+      - uses: microsoft/upgrade-agent-actions@main
         with:
           dotnet-version: '10.0.x'

--- a/cloud-agent/windows/copilot-setup-steps.yml
+++ b/cloud-agent/windows/copilot-setup-steps.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: dotnet/modernize-dotnet-actions@upgrade-agent-actions
+      - uses: microsoft/upgrade-agent-actions@main
         with:
           dotnet-version: '10.0.x'
           #set 'true' to install .NET Framework SDK and targeting packs (4.7.1 – 4.8.1) on Windows runners, required for .NET Framework or desktop workloads


### PR DESCRIPTION
Now that https://github.com/microsoft/upgrade-agent-actions is public, update to use the action at this repo instead of modernize action repo.